### PR TITLE
Fix: отцентрировано меню

### DIFF
--- a/src/components/menu/index.module.css
+++ b/src/components/menu/index.module.css
@@ -9,33 +9,24 @@ html {
 
 #background{
     --local-width-menu: 200px;
-    position: absolute;
-    bottom: calc(var(--menu-bottom) + env(safe-area-inset-bottom, 32px));
-    width: var(--local-width-menu);
-    left: calc((var(--menu-width) - var(--local-width-menu)) / 2 - 2px);
-    display: grid;
-    grid-template-columns: 50% 50%;
-    border-radius: var(--local-width-menu);
-    overflow: hidden;
-    background-color: rgb(255, 255, 255, 8%);
+    margin-left: auto;
+    margin-right: auto;
+    display: flex;
+    gap: 0.5rem;
     backdrop-filter: blur(8px);
-    -webkit-backdrop-filter: blur(8px);
-    border: 1px solid rgba(255,255,255,0.12);
-    box-shadow: 0 6px 20px rgba(0,0,0,0.25);
-    padding: 5px 10px;
-    right: 0;
+    border-radius: var(--local-width-menu);
+    background-color: rgb(255, 255, 255, 8%);
+    margin-bottom: 1rem;
+    padding: 5px;
 }
 
 .menu_item{
     transition: all .3s ease;
     border-radius: var(--local-width-menu);
     display: grid;
-    justify-content: center;
-    align-items: center;
-    grid-template-rows: auto;
     cursor: pointer;
     color: white;
-    padding: 6px;
+    padding: 6px 18px;
     position: relative;
 }
 
@@ -62,7 +53,7 @@ html {
 }
 
 .menu_item_active{
-    color: #0098ea;
+    color: #3ebcff;
 }
 
 .menu_item_inner{

--- a/src/components/message/index.tsx
+++ b/src/components/message/index.tsx
@@ -35,7 +35,7 @@ const Message: FC<PropsType> = memo((props) => {
 
     const username = useMemo(() => {
         const maxLength = 20;
-        if (!props.user.name) return;
+        if (!props?.user?.name) return;
         if (props.user.name.length > maxLength) return props.user.name.slice(0, maxLength);
 
         return props.user.name;


### PR DESCRIPTION
- Меню по центру
- Пришлось осветлить текст активной кнопки, так как при перекрытии темный цвет  хуже читается

Старый цвет
<img width="445" height="405" alt="Screenshot from 2025-12-24 00-09-54" src="https://github.com/user-attachments/assets/dd7f74c0-bbde-4f1b-824a-4489f07855e5" />

Новый цвет
<img width="445" height="405" alt="image" src="https://github.com/user-attachments/assets/33862a15-67c4-481a-8c73-c83ae4b928d7" />
